### PR TITLE
Item Highlighting & Resolve `ltrim` Error

### DIFF
--- a/css/admin.css
+++ b/css/admin.css
@@ -113,8 +113,8 @@
 	flex: 5;
 	height: 128px;
 	margin: 0 15px 15px 0;
+	object-fit: contain;
 	overflow: hidden;
-	width: auto;
 }
 
 .siteorigin-installer-wrap .siteorigin-installer-item .siteorigin-product-content {

--- a/css/admin.css
+++ b/css/admin.css
@@ -88,7 +88,7 @@
 }
 
 .siteorigin-installer-wrap .siteorigin-installer-item.highlight-item .siteorigin-installer-item-body {
-	box-shadow: 0 1px 6px rgba(0, 0, 0, 0.4);
+	box-shadow: 0 1px 12px rgba(0, 0, 0, 0.2);
 }
 
 .siteorigin-installer-wrap .siteorigin-installer-item.highlight-item .siteorigin-installer-item-body .siteorigin-required {

--- a/css/admin.css
+++ b/css/admin.css
@@ -87,6 +87,16 @@
 	display: flex;
 }
 
+.siteorigin-installer-wrap .siteorigin-installer-item.highlight-item .siteorigin-installer-item-body {
+	box-shadow: 0 1px 6px rgba(0, 0, 0, 0.4);
+}
+
+.siteorigin-installer-wrap .siteorigin-installer-item.highlight-item .siteorigin-installer-item-body .siteorigin-required {
+	display: block;
+	color: #0073aa;
+	margin-bottom: 1em;
+}
+
 @media screen and (max-width: 1280px) {
 	.siteorigin-installer-wrap .siteorigin-installer-item {
 		width: 50%;

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -273,6 +273,12 @@ if ( ! class_exists( 'SiteOrigin_Installer_Admin' ) ) {
 				$products = $this->update_product_data();
 			}
 
+			if ( ! empty( $_GET['highlight'] ) && isset( $products[ (string) $_GET['highlight'] ] ) ) {
+				$products[ (string) $_GET['highlight'] ]['weight'] = 9999;
+				uasort( $products, array( $this, 'sort_compare' ) );
+				$highlight = $_GET['highlight'];
+			}
+
 			include SITEORIGIN_INSTALLER_DIR . '/tpl/admin.php';
 		}
 

--- a/tpl/admin.php
+++ b/tpl/admin.php
@@ -92,15 +92,18 @@
 							}
 
 
-							if ( $item['type'] == 'themes' ) {
+							if ( $item['type'] == 'themes' && ! empty( $item['demo'] ) ) {
 								?>
 								<a href="<?php echo esc_url( $item['demo'] ); ?>" target="_blank" rel="noopener noreferrer" class="siteorigin-demo">
 									<?php _e( 'Demo', 'siteorigin-installer' ); ?>			
 								</a>
 							<?php } ?>
-							<a href="<?php echo esc_url( $item['documentation'] ); ?>" target="_blank" rel="noopener noreferrer" class="siteorigin-docs">
-								<?php _e( 'Documentation', 'siteorigin-installer' ); ?>
-							</a>
+
+							<?php if ( ! empty( $item['documentation'] ) ) { ?>
+								<a href="<?php echo esc_url( $item['documentation'] ); ?>" target="_blank" rel="noopener noreferrer" class="siteorigin-docs">
+									<?php _e( 'Documentation', 'siteorigin-installer' ); ?>
+								</a>
+							<?php } ?>
 						</div>
 					</div>
 

--- a/tpl/admin.php
+++ b/tpl/admin.php
@@ -15,8 +15,14 @@
 	<ul class="siteorigin-products">
 		<?php
 		foreach ( $products as $slug => $item ) {
+			$classes = array();
+			$classes[] = $slug == 'siteorigin-premium' || empty( $item['status'] ) ? 'active' : 'inactive';
+
+			if ( ! empty( $highlight ) && $slug == $highlight ) {
+				$classes[] = 'highlight-item';
+			}
 			?>
-			<li class="siteorigin-installer-item siteorigin-<?php echo esc_attr( $item['type'] ); ?> siteorigin-installer-item-<?php echo $slug == 'siteorigin-premium' || empty( $item['status'] ) ? 'active' : 'inactive'; ?>">
+			<li class="siteorigin-installer-item siteorigin-<?php echo esc_attr( $item['type'] ); ?> siteorigin-installer-item-<?php echo implode( ' ', $classes ); ?>">
 				<div
 					class="siteorigin-installer-item-body"
 					data-slug="<?php echo esc_attr( $slug ); ?>"
@@ -32,7 +38,17 @@
 							<?php echo esc_html( $item['name'] ); ?>		
 						</h3>
 						<p class="so-description">
-							<?php echo esc_html( $item['description'] ); ?>		
+							<?php
+							if ( ! empty( $highlight ) && $slug == $highlight ) {
+								echo '<span class="siteorigin-required">';
+								printf(
+									__( 'Required %s', 'siteorigin-installer' ),
+									$item['type'] == 'plugins' ? __( 'Plugin', 'siteorigin-installer' ) : __( 'Theme', 'siteorigin-installer' )
+								);
+								echo '</span>';
+							}
+							echo esc_html( $item['description'] );
+							?>		
 						</p>
 
 						<div class="so-type-indicator">


### PR DESCRIPTION
This PR adds item-highlighting support.

For example, the following will highlight SiteOrigin Widgets Bundle:

`/wp-admin/admin.php?page=siteorigin-installer&highlight=so-widgets-bundle`

![Screenshot 2023-06-13 at 00-44-53 Installer ‹ SO — WordPress](https://github.com/siteorigin/siteorigin-installer/assets/17275120/e0f2a467-335e-4662-97b8-5d59f9a53959)


This PR also resolves an error that can occur if an item doesn't have a documentation link set or a theme doesn't have a demo.
