### PR TITLE
Update Standalone Installer & Prevent It From Being Loaded When Bundled

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,24 @@
+#### 1.0.3 - 9 July 2023
+* Add Installer Status Support. This is used by SiteOrgin plugins and themes to control whether the bundled installer plugin is loaded or not.
+
+#### 1.0.2 - 23 June 2023
+* Delay loading of installer to help with disabling using `siteorigin_add_installer` filter.
+
+#### 1.0.1 - 13 June 2023
+* Add Item Highlighting Support. Example highlight link: `/wp-admin/admin.php?page=siteorigin-installer&highlight=so-widgets-bundle`
+* Resolved error if plugin doesn't have documentation link set.
+* Resolved error if theme doesn't have demo link set.
+
+#### 1.0.0 - 8 June 2023
+* Complete rework of installer. Installer can be found by navigating to WP Admin > SiteOrigin > Installer.
+* Added improved plugin support.
+* Redid the interface to match standardized interface (type filtering included, although no search).
+* Removed TGMPA.
+* Added method of installing themes/plugins via ajax.
+* Added method of handling plugin/theme updates.
+* Improved base notification to continue to show it until dismiss.
+* PHP CS.
+
 #### 0.1.3 - 22 January 2016
 * Added affiliate ID filter.
 

--- a/inc/github-plugin-updater.php
+++ b/inc/github-plugin-updater.php
@@ -10,15 +10,15 @@ class SiteOrigin_Installer_GitHub_Updater {
 		add_filter( 'pre_set_site_transient_update_plugins', array( $this, 'check_for_update' ), 15 );
 		add_filter( 'plugins_api', array( $this, 'plugin_api_call' ), 10, 3 );
 
-		// This line forces an updates call
+		// This line forces an updates call.
 		// set_site_transient( 'update_plugins', null );
 	}
 
 	public function check_for_update( $transient ) {
 		$all_headers = $this->get_plugin_headers();
 
-		if ( version_compare( SITEORIGIN_INSTALLER_VERSION, $all_headers['Version'], '<' ) ) {
-			// There is a newer version available on Github
+		if ( ! empty( $all_headers ) && version_compare( SITEORIGIN_INSTALLER_VERSION, $all_headers['Version'], '<' ) ) {
+			// There is a newer version available on Github.
 			$update = $this->get_plugin_data();
 			$update->new_version = $all_headers['Version'];
 			$update->stable_version = $all_headers['Version'];
@@ -32,7 +32,6 @@ class SiteOrigin_Installer_GitHub_Updater {
 			}
 
 			$transient->response[ $update->slug ] = $update;
-
 		}
 
 		return $transient;
@@ -97,6 +96,9 @@ class SiteOrigin_Installer_GitHub_Updater {
 
 	private function get_plugin_data() {
 		$headers = $this->get_plugin_headers();
+		if ( empty( $headers ) ) {
+			return array();
+		}
 		$data = new stdClass();
 		$data->slug = 'siteorigin-installer-develop/siteorigin-installer.php';
 		$data->plugin_name = $headers['Name'];
@@ -127,7 +129,8 @@ class SiteOrigin_Installer_GitHub_Updater {
 			isset( $args->slug ) &&
 			$args->slug == 'siteorigin-installer-develop/siteorigin-installer.php' &&
 			$action == 'plugin_information' ) {
-			return $this->get_plugin_data();
+			$data = $this->get_plugin_data();
+			return empty( $data ) ? $def : $data;
 		} else {
 			return $def;
 		}

--- a/inc/github-plugin-updater.php
+++ b/inc/github-plugin-updater.php
@@ -106,6 +106,7 @@ class SiteOrigin_Installer_GitHub_Updater {
 		$data->url = $headers['PluginURI'];
 		$data->homepage = $headers['PluginURI'];
 		$data->download_link = 'https://github.com/siteorigin/siteorigin-installer/archive/' . self::UPDATES_BRANCH . '.zip';
+		$data->package = 'https://github.com/siteorigin/siteorigin-installer/archive/' . self::UPDATES_BRANCH . '.zip';
 		$data->icons = array(
 			'1x' => 'https://siteorigin.com/wp-content/themes/siteorigin-theme/pages/installer/images/icon.png',
 		);

--- a/siteorigin-installer.php
+++ b/siteorigin-installer.php
@@ -11,7 +11,7 @@ License URI: http://www.opensource.org/licenses/gpl-license.php
 */
 
 if ( ! defined( 'SITEORIGIN_INSTALLER_VERSION' ) ) {
-	define( 'SITEORIGIN_INSTALLER_VERSION', '1.0.0' );
+	define( 'SITEORIGIN_INSTALLER_VERSION', '1.0.3' );
 	define( 'SITEORIGIN_INSTALLER_DIR', plugin_dir_path( __FILE__ ) );
 	define( 'SITEORIGIN_INSTALLER_URL', plugin_dir_url( __FILE__ ) );
 

--- a/siteorigin-installer.php
+++ b/siteorigin-installer.php
@@ -5,7 +5,7 @@ Plugin URI: https://siteorigin.com/installer/
 Description: This plugin installs all the SiteOrigin themes and plugins you need to get started with your new site.
 Author: SiteOrigin
 Author URI: https://siteorigin.com
-Version: 1.0.0
+Version: 1.0.3
 License: GNU General Public License v3.0
 License URI: http://www.opensource.org/licenses/gpl-license.php
 */

--- a/siteorigin-installer.php
+++ b/siteorigin-installer.php
@@ -15,9 +15,11 @@ if ( ! defined( 'SITEORIGIN_INSTALLER_VERSION' ) ) {
 	define( 'SITEORIGIN_INSTALLER_DIR', plugin_dir_path( __FILE__ ) );
 	define( 'SITEORIGIN_INSTALLER_URL', plugin_dir_url( __FILE__ ) );
 
-	// Setup the Github updater
-	require_once SITEORIGIN_INSTALLER_DIR . '/inc/github-plugin-updater.php';
-	new SiteOrigin_Installer_GitHub_Updater( __FILE__ );
+	// If the installer has been installed as a plugin (rather than bundled), setup the Github updater.
+	if ( basename( SITEORIGIN_INSTALLER_DIR ) == 'siteorigin-installer-develop' ) {
+		require_once SITEORIGIN_INSTALLER_DIR . '/inc/github-plugin-updater.php';
+		new SiteOrigin_Installer_GitHub_Updater( __FILE__ );
+	}
 }
 
 if ( ! class_exists( 'SiteOrigin_Installer' ) ) {


### PR DESCRIPTION
This PR ensures the standalone update workers as expected and updates it to modern standards. This PR also prevents loading the standalone updater when the installer is bundled.