### PR TITLE
Balance notice margin

### DIFF
--- a/css/notices.css
+++ b/css/notices.css
@@ -3,28 +3,28 @@
 	margin: 15px 0;
 }
 #siteorigin-installer-notice .siteorigin-notice-dismiss {
-position: absolute;
-top: 0;
-right: 1px;
-border: none;
-margin: 0;
-padding: 9px;
-background: none;
-color: #787c82;
-cursor: pointer;
-text-decoration: none;
+	background: none;
+	border: none;
+	color: #787c82;
+	cursor: pointer;
+	margin: 0;
+	padding: 9px;
+	position: absolute;
+	right: 1px;
+	text-decoration: none;
+	top: 0;
 }
 #siteorigin-installer-notice .siteorigin-notice-dismiss:before {
+	-webkit-font-smoothing: antialiased;
 	background: none;
 	color: #787c82;
 	content: '\f153';
 	display: block;
 	font: normal 16px/20px 'dashicons';
-	speak: none;
 	height: 20px;
+	speak: none;
 	text-align: center;
 	width: 20px;
-	-webkit-font-smoothing: antialiased;
 }
 
 #siteorigin-installer-notice .siteorigin-notice-dismiss:focus:before,

--- a/css/notices.css
+++ b/css/notices.css
@@ -1,6 +1,6 @@
 #siteorigin-installer-notice {
-	padding-right: 38px;
 	position: relative;
+	margin: 15px 0;
 }
 #siteorigin-installer-notice .siteorigin-notice-dismiss {
 position: absolute;


### PR DESCRIPTION
Before:
![Screenshot 2023-08-01 at 00-35-30 SiteOrigin Widgets ‹ SO — WordPress](https://github.com/siteorigin/siteorigin-installer/assets/17275120/c291e1a8-7c8d-451e-8a62-cbfa77da48e2)

After:
![Screenshot 2023-08-01 at 00-35-58 SiteOrigin Widgets ‹ SO — WordPress](https://github.com/siteorigin/siteorigin-installer/assets/17275120/0a3d1ff8-01ad-495e-abb4-efc467d28d40)

(notice the space below the Widgets Bundle icon being consistent with after the notice)