### PR TITLE
Prevent Potential 404 When Clicking SiteOrigin Admin Link

### DIFF
--- a/inc/admin.php
+++ b/inc/admin.php
@@ -27,7 +27,7 @@ if ( ! class_exists( 'SiteOrigin_Installer_Admin' ) ) {
 
 		public function display_admin_notices() {
 			global $pagenow;
-			
+
 			if (
 				! get_option( 'siteorigin_installer_admin_dismissed' ) &&
 				current_user_can( 'install_plugins' ) &&
@@ -82,7 +82,7 @@ if ( ! class_exists( 'SiteOrigin_Installer_Admin' ) ) {
 					__( 'SiteOrigin', 'siteorigin-installer' ),
 					__( 'SiteOrigin', 'siteorigin-installer' ),
 					false,
-					'siteorigin',
+					'admin.php?page=siteorigin-installer',
 					false,
 					SITEORIGIN_INSTALLER_URL . '/img/icon.svg',
 					66
@@ -100,7 +100,10 @@ if ( ! class_exists( 'SiteOrigin_Installer_Admin' ) ) {
 		}
 
 		public function enqueue_scripts( $prefix ) {
-			if ( $prefix !== 'siteorigin_page_siteorigin-installer' ) {
+			if (
+				$prefix !== 'admin_page_siteorigin-installer' &&
+				$prefix !== 'siteorigin_page_siteorigin-installer'
+			) {
 				return;
 			}
 


### PR DESCRIPTION
[Reported here](https://siteorigin.com/thread/the-wp-admin-siteorigin-url-doesnt-work-for-bitnami-wordpress-multisite/)

This PR resolves an issue that can occur on certain non-standard setups. When the user clicks the SiteOrigin Admin link they'll experience a 404 as WordPress won't link to the correct page. This PR corrects this.