### PR TITLE
Change text domains to prevent potential conflict

### DIFF
--- a/inc/admin.php
+++ b/inc/admin.php
@@ -46,8 +46,8 @@ if ( ! class_exists( 'SiteOrigin_Installer_Admin' ) ) {
 					<p>
 						<?php
 						printf(
-							__( '%s to install recommended SiteOrigin plugins and a SiteOrigin theme to get your site going.', 'siteorigin-installer' ),
-							'<a href="' . esc_url( admin_url( 'admin.php?page=siteorigin-installer' ) ) . '" target="_blank" rel="noopener noreferrer" >' . __( 'Click here', 'siteorigin-installer' ) . '</a>'
+							__( '%s to install recommended SiteOrigin plugins and a SiteOrigin theme to get your site going.', 'siteorigin-installer-text-domain' ),
+							'<a href="' . esc_url( admin_url( 'admin.php?page=siteorigin-installer' ) ) . '" target="_blank" rel="noopener noreferrer" >' . __( 'Click here', 'siteorigin-installer-text-domain' ) . '</a>'
 						);
 						?>
 					</p>
@@ -83,8 +83,8 @@ if ( ! class_exists( 'SiteOrigin_Installer_Admin' ) ) {
 				empty( $GLOBALS['admin_page_hooks']['siteorigin'] )
 			) {
 				add_menu_page(
-					__( 'SiteOrigin', 'siteorigin-installer' ),
-					__( 'SiteOrigin', 'siteorigin-installer' ),
+					__( 'SiteOrigin', 'siteorigin-installer-text-domain' ),
+					__( 'SiteOrigin', 'siteorigin-installer-text-domain' ),
 					false,
 					'admin.php?page=siteorigin-installer',
 					false,
@@ -95,8 +95,8 @@ if ( ! class_exists( 'SiteOrigin_Installer_Admin' ) ) {
 
 			add_submenu_page(
 				'siteorigin',
-				__( 'Installer', 'siteorigin-installer' ),
-				__( 'Installer', 'siteorigin-installer' ),
+				__( 'Installer', 'siteorigin-installer-text-domain' ),
+				__( 'Installer', 'siteorigin-installer-text-domain' ),
 				'manage_options',
 				'siteorigin-installer',
 				array( $this, 'display_admin_page' )
@@ -130,7 +130,7 @@ if ( ! class_exists( 'SiteOrigin_Installer_Admin' ) ) {
 				'soInstallerAdmin',
 				array(
 					'manageUrl' => wp_nonce_url( admin_url( 'admin-ajax.php?action=siteorigin_installer_manage' ), 'siteorigin-installer-manage' ),
-					'activateText' => __( 'Activate', 'siteorigin-installer' ),
+					'activateText' => __( 'Activate', 'siteorigin-installer-text-domain' ),
 				)
 			);
 		}

--- a/tpl/admin.php
+++ b/tpl/admin.php
@@ -2,13 +2,13 @@
 	<div class="siteorigin-installer-header">
 		<h1 class="siteorigin-logo">
 			<img src="<?php echo esc_url( plugin_dir_url( __FILE__ ) ) . '../img/siteorigin.svg'; ?>" />
-			<?php esc_html_e( 'SiteOrigin Installer', 'siteorigin-installer' ); ?>
+			<?php esc_html_e( 'SiteOrigin Installer', 'siteorigin-installer-text-domain' ); ?>
 		</h1>
 
 		<ul class="page-sections">
-			<li><a href="#" data-section="plugins"><?php esc_html_e( 'Plugins', 'siteorigin-installer' ); ?></a></li>
-			<li><a href="#" data-section="themes"><?php esc_html_e( 'Themes', 'siteorigin-installer' ); ?></a></li>
-			<li class="active-section"><a href="#" data-section="all"><?php esc_html_e( 'All', 'siteorigin-installer' ); ?></a></li>
+			<li><a href="#" data-section="plugins"><?php esc_html_e( 'Plugins', 'siteorigin-installer-text-domain' ); ?></a></li>
+			<li><a href="#" data-section="themes"><?php esc_html_e( 'Themes', 'siteorigin-installer-text-domain' ); ?></a></li>
+			<li class="active-section"><a href="#" data-section="all"><?php esc_html_e( 'All', 'siteorigin-installer-text-domain' ); ?></a></li>
 		</ul>
 	</div>
 
@@ -42,8 +42,8 @@
 							if ( ! empty( $highlight ) && $slug == $highlight ) {
 								echo '<span class="siteorigin-required">';
 								printf(
-									esc_html__( 'Required %s', 'siteorigin-installer' ),
-									$item['type'] == 'plugins' ? esc_html__( 'Plugin', 'siteorigin-installer' ) : esc_html__( 'Theme', 'siteorigin-installer' )
+									esc_html__( 'Required %s', 'siteorigin-installer-text-domain' ),
+									$item['type'] == 'plugins' ? esc_html__( 'Plugin', 'siteorigin-installer-text-domain' ) : esc_html__( 'Theme', 'siteorigin-installer-text-domain' )
 								);
 								echo '</span>';
 							}
@@ -54,9 +54,9 @@
 						<div class="so-type-indicator">
 							<?php
 							if ( $item['type'] == 'plugins' ) {
-								esc_html_e( 'Plugin', 'siteorigin-installer' );
+								esc_html_e( 'Plugin', 'siteorigin-installer-text-domain' );
 							} else {
-								esc_html_e( 'Theme', 'siteorigin-installer' );
+								esc_html_e( 'Theme', 'siteorigin-installer-text-domain' );
 							}
 							?>
 						</div>
@@ -78,20 +78,20 @@
 									}
 									?>
 									<a href="<?php echo esc_url( $premium_url ); ?>" target="_blank" rel="noopener noreferrer" class="button-primary">
-										<?php esc_html_e( 'Get SiteOrigin Premium', 'siteorigin-installer' ); ?>
+										<?php esc_html_e( 'Get SiteOrigin Premium', 'siteorigin-installer-text-domain' ); ?>
 									</a>
 									<?php
 								} elseif ( ! empty( $item['status'] ) || $item['type'] == 'themes' ) {
 									if ( $item['status'] == 'install' ) {
-										$text = __( 'Install', 'siteorigin-installer' );
+										$text = __( 'Install', 'siteorigin-installer-text-domain' );
 									} else {
-										$text = __( 'Activate', 'siteorigin-installer' );
+										$text = __( 'Activate', 'siteorigin-installer-text-domain' );
 									}
 									require 'action-btn.php';
 								}
 
 								if ( ! empty( $item['update'] ) ) {
-									$text = __( 'Update', 'siteorigin-installer' );
+									$text = __( 'Update', 'siteorigin-installer-text-domain' );
 									$item['status'] = 'update';
 									require 'action-btn.php';
 								}
@@ -104,13 +104,13 @@
 							) {
 								?>
 								<a href="<?php echo esc_url( $item['demo'] ); ?>" target="_blank" rel="noopener noreferrer" class="siteorigin-demo">
-									<?php esc_html_e( 'Demo', 'siteorigin-installer' ); ?>
+									<?php esc_html_e( 'Demo', 'siteorigin-installer-text-domain' ); ?>
 								</a>
 							<?php } ?>
 
 							<?php if ( ! empty( $item['documentation'] ) ) { ?>
 								<a href="<?php echo esc_url( $item['documentation'] ); ?>" target="_blank" rel="noopener noreferrer" class="siteorigin-docs">
-									<?php esc_html_e( 'Documentation', 'siteorigin-installer' ); ?>
+									<?php esc_html_e( 'Documentation', 'siteorigin-installer-text-domain' ); ?>
 								</a>
 							<?php } ?>
 						</div>


### PR DESCRIPTION
The plugin build is looking for a `siteorigin-installer` and is replacing it with the relevant plugin text domain. This can result in the installer sub-menu URL being incorrect if the main submenu isn't registered.