### PR TITLE
Fix Menu Not Showing Due to Permissions

### DIFF
--- a/inc/admin.php
+++ b/inc/admin.php
@@ -85,7 +85,7 @@ if ( ! class_exists( 'SiteOrigin_Installer_Admin' ) ) {
 				add_menu_page(
 					__( 'SiteOrigin', 'siteorigin-installer-text-domain' ),
 					__( 'SiteOrigin', 'siteorigin-installer-text-domain' ),
-					false,
+					'manage_options',
 					'admin.php?page=siteorigin-installer',
 					false,
 					SITEORIGIN_INSTALLER_URL . '/img/icon.svg',


### PR DESCRIPTION
The installer menu wasn't showing for me when premium was disabled and this restored it. Unsure why it was required for me now.