### PR TITLE
Installer: Change premium teaser to activate button if SiteOrigin Premium is installed but not active

### DIFF
--- a/tpl/admin.php
+++ b/tpl/admin.php
@@ -70,24 +70,33 @@
 								! empty( $item['update'] ) ||
 								$item['type'] == 'themes'
 							) {
-								if ( $slug == 'siteorigin-premium' ) {
-									$premium_url = 'https://siteorigin.com/downloads/premium/';
-									$affiliate_id = apply_filters( 'siteorigin_premium_affiliate_id', '' );
-									if ( $affiliate_id && is_numeric( $affiliate_id ) ) {
-										$premium_url = add_query_arg( 'ref', urlencode( $affiliate_id ), $premium_url );
-									}
-									?>
-									<a href="<?php echo esc_url( $premium_url ); ?>" target="_blank" rel="noopener noreferrer" class="button-primary">
-										<?php esc_html_e( 'Get SiteOrigin Premium', 'siteorigin-installer-text-domain' ); ?>
-									</a>
-									<?php
-								} elseif ( ! empty( $item['status'] ) || $item['type'] == 'themes' ) {
+								$text = '';
+								if ( ! empty( $item['status'] ) || $item['type'] == 'themes' ) {
 									if ( $item['status'] == 'install' ) {
+
+
+										if ( $slug == 'siteorigin-premium' ) {
+											$premium_url = 'https://siteorigin.com/downloads/premium/';
+											$affiliate_id = apply_filters( 'siteorigin_premium_affiliate_id', '' );
+											if ( $affiliate_id && is_numeric( $affiliate_id ) ) {
+												$premium_url = add_query_arg( 'ref', urlencode( $affiliate_id ), $premium_url );
+											}
+											?>
+											<a href="<?php echo esc_url( $premium_url ); ?>" target="_blank" rel="noopener noreferrer" class="button-primary">
+												<?php esc_html_e( 'Get SiteOrigin Premium', 'siteorigin-installer-text-domain' ); ?>
+											</a>
+											<?php
+										} else {
+
 										$text = __( 'Install', 'siteorigin-installer-text-domain' );
+										}
 									} else {
 										$text = __( 'Activate', 'siteorigin-installer-text-domain' );
 									}
-									require 'action-btn.php';
+
+									if ( ! empty( $text ) ) {
+										require 'action-btn.php';
+									}
 								}
 
 								if ( ! empty( $item['update'] ) ) {


### PR DESCRIPTION
Resolve https://github.com/siteorigin/siteorigin-installer/issues/26

Please note that the addon list has a cache. If you don't see the correct result, try activating/deactivating the plugin that's currently loading the installer.