### PR TITLE
Exclude `.gitmodules` From Builds

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -9,8 +9,9 @@ tests
 
 # Files
 .distignore
-.gitignore
 .gitattributes
+.gitignore
+.gitmodules
 .editorconfig
 .eslintrc
 .eslintignore


### PR DESCRIPTION
This file shouldn't be included in the release version.